### PR TITLE
var-gpio-utils: Fix LICENSE to match SPDX strings

### DIFF
--- a/recipes-support/var-gpio-utils/var-gpio-utils.bb
+++ b/recipes-support/var-gpio-utils/var-gpio-utils.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Install gpio utilities and scripts used by Variscite SOMs"
 
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
 
 SRC_URI = "file://gpiochip"


### PR DESCRIPTION
Fixes
WARNING: var-gpio-utils-1.0-r0 do_package_qa: QA Issue: Recipe LICENSE includes obsolete licenses GPLv2 [obsolete-license]