### PR TITLE
var-mii: Remove setting S

### DIFF
--- a/recipes-bsp/var-mii/var-mii_git.inc
+++ b/recipes-bsp/var-mii/var-mii_git.inc
@@ -8,6 +8,4 @@ SRC_URI = "git://git@github.com/varigit/var-mii.git;protocol=ssh;branch=master"
 PV = "1.0+git${SRCPV}"
 SRCREV = "c9e7ffe6bff5074a47c4a5411692759441813d64"
 
-S = "${WORKDIR}/git"
-
 TARGET_CC_ARCH += "${LDFLAGS}"


### PR DESCRIPTION
default S is set in UNPACKDIR whinlatter and newer releases use that